### PR TITLE
MySQL getBan - single querry instead of querry whole table

### DIFF
--- a/src/main/java/net/craftminecraft/bungee/bungeeban/BanManager.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/BanManager.java
@@ -2,7 +2,6 @@ package net.craftminecraft.bungee.bungeeban;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -60,9 +59,9 @@ public class BanManager {
 
 	public static BanEntry getBan(String playerorip, String server) {
 		if (isIP(playerorip)) {
-			return banstore.getIPBanList().get(playerorip, server);
+			return banstore.isIPBanned(playerorip, server);
 		} else {
-			return banstore.getBanList().get(playerorip.toLowerCase(), server);
+			return banstore.isBanned(playerorip.toLowerCase(), server);
 		}
 	}
 

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/BungeeBan.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/BungeeBan.java
@@ -2,8 +2,6 @@ package net.craftminecraft.bungee.bungeeban;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -15,7 +13,6 @@ import net.craftminecraft.bungee.bungeeban.util.MainConfig;
 import net.craftminecraft.bungee.bungeeban.util.PluginLogger;
 import net.craftminecraft.bungee.bungeeban.util.Metrics;
 import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 
 

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/FileBanStore.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/FileBanStore.java
@@ -17,7 +17,6 @@ import com.google.common.collect.Table;
 
 import net.craftminecraft.bungee.bungeeban.BungeeBan;
 import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.plugin.Plugin;
 
 
 public class FileBanStore implements IBanStore {
@@ -235,5 +234,17 @@ public class FileBanStore implements IBanStore {
 			plugin.getLogger().log(Level.SEVERE, "Could not load banlist files.", e);
 			return;
 		}
+	}
+
+	@Override
+	public BanEntry isBanned(String player, String server) {
+		removeExpired();
+		return playerBanned.get(player, server);
+	}
+
+	@Override
+	public BanEntry isIPBanned(String ip, String server) {
+		removeExpired();
+		return ipBanned.get(ip, server);
 	}
 }

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/IBanStore.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/IBanStore.java
@@ -43,6 +43,9 @@ public interface IBanStore {
 	Table<String,String,BanEntry> getBanList();
 	Table<String,String,BanEntry> getIPBanList();
 	
+	BanEntry isBanned(String player, String server);
+	BanEntry isIPBanned(String ip, String server);
+	
 	/**
 	 * Reloads the list of bans from whatever storage into memory.
 	 * If no list is kept in memory, should just return without doing anything.

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/MySQLBanStore.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/MySQLBanStore.java
@@ -138,7 +138,7 @@ public class MySQLBanStore implements IBanStore {
 			return false;
 		}
 	}
-
+	
 	@Override
 	public Table<String,String,BanEntry> getBanList() {
 		try {
@@ -208,4 +208,72 @@ public class MySQLBanStore implements IBanStore {
 		return;
 	}
 
+	@Override
+	public BanEntry isBanned(String player, String server) {
+		PreparedStatement stmt;
+		try {
+			stmt = connection.prepare("SELECT * FROM bungeeban_playerbans WHERE banned = ? " +
+				    "AND server = ?");
+			stmt.setString(1, player);
+			stmt.setString(2, server);
+			ResultSet rs = connection.query(stmt);
+			
+			if (rs.first()) {
+					try {
+						BanEntry.Builder builder = new BanEntry.Builder(rs.getString("banned"))
+							.created(dateFormat.parse(rs.getString("created")))
+							.server(rs.getString("server"))
+							.reason(rs.getString("reason"))
+							.source(rs.getString("source"));
+						if (rs.getNString("expiry") != null) {
+							builder.expiry(dateFormat.parse(rs.getNString("expiry")));
+						}
+						return builder.build();
+					} catch (ParseException e) {
+						logger.severe("Invalid date format for entry " + rs.getString("banned") +
+							":" + rs.getString("server"));
+						return null;
+					}
+			}
+		} catch (SQLException e) {
+			logger.severe("isBanned failed, " + e.getMessage());
+			return null;
+		}
+		return null;
+	}
+
+	@Override
+	public BanEntry isIPBanned(String ip, String server) {
+		PreparedStatement stmt;
+		try {
+			stmt = connection.prepare("SELECT * FROM bungeeban_ipbans WHERE player = ? AND server = ?");
+			stmt.setString(1, ip);
+			stmt.setString(2, server);
+			ResultSet rs = connection.query(stmt);
+			
+			if (rs.first()) {
+					try {
+						BanEntry.Builder builder = new BanEntry.Builder(rs.getString("banned"))
+							.created(dateFormat.parse(rs.getString("created")))
+							.server(rs.getString("server"))
+							.reason(rs.getString("reason"))
+							.source(rs.getString("source"));
+						if (rs.getNString("expiry") != null) {
+							builder.expiry(dateFormat.parse(rs.getNString("expiry")));
+						}
+						return builder.ipban().build();
+					} catch (ParseException e) {
+						logger.severe("Invalid date format for entry " + rs.getString("banned") +
+							":" + rs.getString("server"));
+						return null;
+					}
+			}
+			
+			return null;
+		} catch (SQLException e) {
+			logger.severe("Global UnbanIP failed, " + e.getMessage());
+			return null;
+		}
+	}
+	
 }

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/command/MigrateCommand.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/command/MigrateCommand.java
@@ -8,7 +8,7 @@ import net.craftminecraft.bungee.bungeeban.banstore.IBanStore;
 import net.craftminecraft.bungee.bungeeban.banstore.MySQLBanStore;
 import net.craftminecraft.bungee.bungeeban.util.MainConfig;
 import net.craftminecraft.bungee.bungeeban.util.Utils;
-import net.craftminecraft.bungee.bungeeyaml.InvalidConfigurationException;
+import net.craftminecraft.bungee.bungeeyaml.bukkitapi.InvalidConfigurationException;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/command/ReloadBansCommand.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/command/ReloadBansCommand.java
@@ -4,7 +4,7 @@ package net.craftminecraft.bungee.bungeeban.command;
 import net.craftminecraft.bungee.bungeeban.BanManager;
 import net.craftminecraft.bungee.bungeeban.util.MainConfig;
 import net.craftminecraft.bungee.bungeeban.util.Utils;
-import net.craftminecraft.bungee.bungeeyaml.InvalidConfigurationException;
+import net.craftminecraft.bungee.bungeeyaml.bukkitapi.InvalidConfigurationException;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/listener/PluginMessageListener.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/listener/PluginMessageListener.java
@@ -23,7 +23,7 @@ public class PluginMessageListener implements Listener {
 		// Checks if the one sending the message is the server.
 		if (e.getTag() != "BungeeBan" || !(e.getSender() instanceof Server))
 			return;
-		String servername = ((Server)e.getSender()).getInfo().getName();
+		//String servername = ((Server)e.getSender()).getInfo().getName();
 		ByteArrayInputStream bytestream = new ByteArrayInputStream(e.getData());
 		DataInputStream datastream = new DataInputStream(bytestream);
 		try {

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/util/MainConfig.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/util/MainConfig.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.logging.Level;
 
 import net.craftminecraft.bungee.bungeeban.BungeeBan;
-import net.craftminecraft.bungee.bungeeyaml.InvalidConfigurationException;
+import net.craftminecraft.bungee.bungeeyaml.bukkitapi.InvalidConfigurationException;
 import net.craftminecraft.bungee.bungeeyaml.supereasyconfig.Config;
 
 public class MainConfig extends Config {


### PR DESCRIPTION
Instead of getting the whole table of banned players, when trying to get a ban, just get the single BanEntry for the player & server.

This keeps the traffic and the work time on the database low.
