### PR TITLE
REDO: MySQL getBan - single querry instead of querry whole table

### DIFF
--- a/src/main/java/net/craftminecraft/bungee/bungeeban/BanManager.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/BanManager.java
@@ -60,9 +60,9 @@ public class BanManager {
 
 	public static BanEntry getBan(String playerorip, String server) {
 		if (isIP(playerorip)) {
-			return banstore.getIPBanList().get(playerorip, server);
+			return banstore.isIPBanned(playerorip, server);
 		} else {
-			return banstore.getBanList().get(playerorip.toLowerCase(), server);
+			return banstore.isBanned(playerorip.toLowerCase(), server);
 		}
 	}
 

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/FileBanStore.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/FileBanStore.java
@@ -87,6 +87,18 @@ public class FileBanStore implements IBanStore {
 		return ipBanned;
 	}
 	
+	@Override
+	public BanEntry isBanned(String player, String server) {
+		removeExpired();
+		return playerBanned.get(player, server);
+	}
+
+	@Override
+	public BanEntry isIPBanned(String ip, String server) {
+		removeExpired();
+		return ipBanned.get(ip, server);
+	}
+	
 	private void save() {
         try {
         	//save player bans

--- a/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/IBanStore.java
+++ b/src/main/java/net/craftminecraft/bungee/bungeeban/banstore/IBanStore.java
@@ -43,6 +43,9 @@ public interface IBanStore {
 	Table<String,String,BanEntry> getBanList();
 	Table<String,String,BanEntry> getIPBanList();
 	
+	BanEntry isBanned(String player, String server);
+	BanEntry isIPBanned(String ip, String server);
+	
 	/**
 	 * Reloads the list of bans from whatever storage into memory.
 	 * If no list is kept in memory, should just return without doing anything.


### PR DESCRIPTION
REDO of a messed pull request of a messed up maven project.

Instead of getting the whole table of banned players, when trying to get a ban, just get the single BanEntry for the player & server.

This keeps the traffic and the work time on the database low.
